### PR TITLE
Add notifier hook for toast messages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "daisyui": "^4.10.0"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,12 +13,14 @@ import WorkOrders from "./pages/WorkOrders";
 import Reports from "./pages/Reports";
 import Settings from "./pages/Settings";
 import { AuthProvider } from "./hooks/useAuth";
+import { NotifierProvider } from "./hooks/useNotifier";
 
 function App() {
   return (
     <Router>
       <AuthProvider>
-        <Routes>
+        <NotifierProvider>
+          <Routes>
           <Route path="/login" element={<Login />} />
           <Route path="/complete-profile" element={<CompleteProfile />} />
           <Route element={<MainLayout />}>
@@ -29,7 +31,8 @@ function App() {
             <Route path="/reports" element={<Reports />} />
             <Route path="/settings" element={<Settings />} />
           </Route>
-        </Routes>
+          </Routes>
+        </NotifierProvider>
       </AuthProvider>
     </Router>
   );

--- a/frontend/src/hooks/useNotifier.jsx
+++ b/frontend/src/hooks/useNotifier.jsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useState } from "react";
+
+const NotifierContext = createContext(null);
+
+export function NotifierProvider({ children }) {
+  const [messages, setMessages] = useState([]);
+
+  const remove = (id) =>
+    setMessages((msgs) => msgs.filter((m) => m.id !== id));
+
+  const notify = (text, type = "info", duration = 3000) => {
+    const id = Date.now();
+    setMessages((msgs) => [...msgs, { id, text, type }]);
+    setTimeout(() => remove(id), duration);
+  };
+
+  const notifySuccess = (text) => notify(text, "success");
+  const notifyError = (text) => notify(text, "error");
+
+  return (
+    <NotifierContext.Provider value={{ notifySuccess, notifyError }}>
+      {children}
+      <div className="toast toast-end">
+        {messages.map((m) => (
+          <div key={m.id} className={`alert alert-${m.type}`}>
+            <span>{m.text}</span>
+          </div>
+        ))}
+      </div>
+    </NotifierContext.Provider>
+  );
+}
+
+export function useNotifier() {
+  const ctx = useContext(NotifierContext);
+  if (!ctx) throw new Error("useNotifier must be used within NotifierProvider");
+  return ctx;
+}

--- a/frontend/src/pages/CompleteProfile.jsx
+++ b/frontend/src/pages/CompleteProfile.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { completeUserProfile, getCurrentUser, isProfileComplete } from "../api"; // ✅ Ensure correct import path
+import { useNotifier } from "../hooks/useNotifier";
 
 function CompleteProfile() {
   const [formData, setFormData] = useState({
@@ -13,7 +14,7 @@ function CompleteProfile() {
 
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const { notifySuccess, notifyError } = useNotifier();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -21,7 +22,7 @@ function CompleteProfile() {
       try {
         const currentUser = await getCurrentUser();
         if (!currentUser || !currentUser.id) {
-          setError("User session is missing. Please log in again.");
+          notifyError("User session is missing. Please log in again.");
           setLoading(false);
           return;
         }
@@ -29,7 +30,7 @@ function CompleteProfile() {
         setLoading(false);
       } catch (err) {
         console.error("❌ Get user error:", err);
-        setError("Authentication error. Please log in again.");
+        notifyError("Authentication error. Please log in again.");
         setLoading(false);
       }
     };
@@ -39,20 +40,19 @@ function CompleteProfile() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setError(null);
 
     if (!user || !user.id) {
-      setError("User session is missing. Please log in again.");
+      notifyError("User session is missing. Please log in again.");
       return;
     }
 
     try {
       await completeUserProfile({ ...formData, id: user.id, email: user.email });
-      alert("✅ Profile updated successfully!");
+      notifySuccess("Profile updated successfully!");
       navigate("/company-overview"); // ✅ Redirect to company overview
     } catch (err) {
       console.error("❌ Profile completion error:", err);
-      setError(err.message || "Failed to complete profile. Please try again.");
+      notifyError(err.message || "Failed to complete profile. Please try again.");
     }
   };
 
@@ -61,7 +61,6 @@ function CompleteProfile() {
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6 bg-gray-100 min-h-screen">
       <h2 className="text-3xl font-bold text-gray-900">Complete Your Profile</h2>
-      {error && <p className="text-red-600">{error}</p>}
       <form onSubmit={handleSubmit} className="space-y-4 bg-white p-6 rounded-lg shadow-lg">
         <input type="text" name="full_name" placeholder="Full Name" value={formData.full_name} onChange={(e) => setFormData({ ...formData, full_name: e.target.value })} className="w-full border p-2 rounded" required />
         <input type="text" name="role" placeholder="Role" value={formData.role} onChange={(e) => setFormData({ ...formData, role: e.target.value })} className="w-full border p-2 rounded" required />

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,24 +1,23 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { signIn, signUp, isProfileComplete } from "../api";
+import { useNotifier } from "../hooks/useNotifier";
 
 function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [isSignUp, setIsSignUp] = useState(false);
-  const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
-  const [confirmationMessage, setConfirmationMessage] = useState("");
+  const { notifySuccess, notifyError } = useNotifier();
   const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setError(null);
     setLoading(true);
 
     if (isSignUp && password !== confirmPassword) {
-      setError("Passwords do not match!");
+      notifyError("Passwords do not match!");
       setLoading(false);
       return;
     }
@@ -26,7 +25,7 @@ function Login() {
     try {
       if (isSignUp) {
         await signUp(email, password);
-        setConfirmationMessage("✅ Check your email to confirm your account!");
+        notifySuccess("Check your email to confirm your account!");
       } else {
         try {
           const user = await signIn(email, password);
@@ -37,12 +36,12 @@ function Login() {
           navigate(profileCompleted ? "/company-overview" : "/complete-profile");
         } catch (err) {
           console.error("Sign in error:", err);
-          setError(err.message);
+          notifyError(err.message);
         }
       }
     } catch (err) {
-      setError(err.message);
       console.error("❌ Authentication Error:", err.message);
+      notifyError(err.message);
     } finally {
       setLoading(false);
     }
@@ -54,8 +53,6 @@ function Login() {
         <h2 className="text-center text-3xl font-bold text-gray-900">
           {isSignUp ? "Create an Account" : "Sign In"}
         </h2>
-        {confirmationMessage && <p className="text-green-500 text-center">{confirmationMessage}</p>}
-        {error && <p className="text-red-500 text-center">{error}</p>}
 
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           <input type="email" required className="block w-full p-3 border rounded-md"

--- a/frontend/src/pages/PMPlanner.jsx
+++ b/frontend/src/pages/PMPlanner.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import axios from "axios";
 import { saveAs } from "file-saver";
+import { useNotifier } from "../hooks/useNotifier";
 
 // UI Components
 function Input({ label, name, value, onChange, placeholder, type = "text" }) {
@@ -56,7 +57,7 @@ export default function PMPlanner() {
 
   const [pmPlan, setPmPlan] = useState([]);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const { notifyError } = useNotifier();
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -65,7 +66,6 @@ export default function PMPlanner() {
 
   const generatePMPlan = async () => {
     setLoading(true);
-    setError(null);
     try {
       const res = await axios.post(
         `${API_BASE_URL}/generate_pm_plan`,
@@ -78,7 +78,7 @@ export default function PMPlanner() {
       }
     } catch (err) {
       console.error("❌ API error:", err);
-      setError("Something went wrong. Please check your inputs or try again.");
+      notifyError("Something went wrong. Please check your inputs or try again.");
     } finally {
       setLoading(false);
     }
@@ -97,7 +97,7 @@ export default function PMPlanner() {
       saveAs(blob, `PM_Plan_${assetData.name || "Asset"}.xlsx`);
     } catch (err) {
       console.error("❌ Excel download failed:", err);
-      setError("Failed to export Excel. Please try again.");
+      notifyError("Failed to export Excel. Please try again.");
     }
   };
 
@@ -160,7 +160,6 @@ export default function PMPlanner() {
           {loading ? "Generating..." : "Generate Plan"}
         </Button>
 
-        {error && <p className="text-red-600 mt-3">{error}</p>}
       </Card>
 
       <Card title="Maintenance Plan Results">

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -15,5 +15,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [require("daisyui")],
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tailwindcss": "^3.4.1",
+    "daisyui": "^4.10.0",
     "typescript": "^5.2.2",
     "vite": "^5.0.0"
   },


### PR DESCRIPTION
## Summary
- add `useNotifier` context for DaisyUI toast notifications
- wrap app with `NotifierProvider`
- show toast messages on login, profile completion, and PM planner pages
- enable DaisyUI plugin in Tailwind config and add dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684a45967c3483338156544e7b0502cd